### PR TITLE
Add mod_cloudflare test recipe

### DIFF
--- a/spec/modules/mod_cloudflare_spec.rb
+++ b/spec/modules/mod_cloudflare_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 platforms = supported_platforms.select { |key, _| %w(debian ubuntu redhat centos fedora).include?(key) }
 
-describe 'apache2::mod_cloudflare' do
+# use the test fixture cookbook because we need apt_repository or yum_repository
+describe 'apache2_test::mod_cloudflare' do
   platforms.each do |platform, versions|
     versions.each do |version|
       context "on #{platform.capitalize} #{version}" do

--- a/test/fixtures/cookbooks/apache2_test/metadata.rb
+++ b/test/fixtures/cookbooks/apache2_test/metadata.rb
@@ -7,9 +7,11 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
 depends          'apache2'
+depends          'apt'
 depends          'jpackage'
 depends          'openldap'
 depends          'tomcat'
+depends          'yum'
 depends          'yum-epel'
 
 recipe           'apache2_test::default', 'Test example for default recipe'

--- a/test/fixtures/cookbooks/apache2_test/recipes/mod_cloudflare.rb
+++ b/test/fixtures/cookbooks/apache2_test/recipes/mod_cloudflare.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: apache2_test
+# Recipe:: mod_cloudflare
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'apache2::mod_cloudflare'


### PR DESCRIPTION
Add mod_cloudflare test recipe to apache2_test fixture cookbook.
apache2::mod_cloudflare requires the apt cookbook or yum cookbook for the repository resource, but I didn't want to add the dependency to the main metadata.rb.
